### PR TITLE
feat: Update to CPython version 3.8.11 base image

### DIFF
--- a/docker/centos/Dockerfile
+++ b/docker/centos/Dockerfile
@@ -1,4 +1,4 @@
-ARG BUILDER_IMAGE=neubauergroup/centos-build-base:latest
+ARG BUILDER_IMAGE=neubauergroup/centos-build-base:3.8.11
 FROM neubauergroup/centos-root-base:6.24.00 as root_cern_image
 FROM ${BUILDER_IMAGE} as builder
 


### PR DESCRIPTION
Update to use [CPython version `3.8.11`](https://www.python.org/downloads/release/python-3811/).

```
* Update to use CPython version 3.8.11 base image
   - c.f. neubauergroup/centos-build-base:3.8.11
```